### PR TITLE
Add hasTag and groupByTag helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ All credit goes to [The Hashicorp Consul Template project on GitHub][Consul Temp
 Specifically:
 * Added tagMap
 * Added byDomainPath
+* Added hasTag
 * Changed services to not split content before . into a tag search
 
 Consul Template
@@ -589,6 +590,19 @@ You can also access deeply nested values:
 ```
 
 Note: You will need to have a reasonable format about your data in Consul. Please see Golang's text/template package for more information.
+
+##### `hasTag`
+Takes a list of services (as may be returned from a [`services`](#services) function) and returns only those services which have the given tag.
+
+This only acts on services which contain tags in the format:
+* domain=echo.testing.mydomain.com
+* path=/hello
+
+```liquid
+{{ range services | hasTag "domain" }}
+# ...
+{{end}}
+```
 
 ##### `in`
 Determines if a needle is within an iterable element.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Specifically:
 * Added tagMap
 * Added byDomainPath
 * Added hasTag
+* Added groupByTag
 * Changed services to not split content before . into a tag search
 
 Consul Template
@@ -590,6 +591,20 @@ You can also access deeply nested values:
 ```
 
 Note: You will need to have a reasonable format about your data in Consul. Please see Golang's text/template package for more information.
+
+##### `groupByTag`
+Takes a list of services (as may be returned from a [`services`](#services) function) and returns a map of them keyed against the provided tag.
+Services which do not have the specified tag are ignored.
+
+This only acts on services which contain tags in the format:
+* domain=echo.testing.mydomain.com
+* path=/hello
+
+```liquid
+{{ range $location, $services := services | groupByTag "path" }}
+# ...
+{{end}}
+```
 
 ##### `hasTag`
 Takes a list of services (as may be returned from a [`services`](#services) function) and returns only those services which have the given tag.

--- a/template.go
+++ b/template.go
@@ -114,6 +114,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"byDomainPath":    byDomainPath,
 		"withSSLService":  withSSLService,
 		"contains":        contains,
+		"groupByTag":      groupByTag,
 		"hasTag":          hasTag,
 		"env":             env,
 		"explode":         explode,

--- a/template.go
+++ b/template.go
@@ -114,6 +114,7 @@ func funcMap(brain *Brain, used, missing map[string]dep.Dependency) template.Fun
 		"byDomainPath":    byDomainPath,
 		"withSSLService":  withSSLService,
 		"contains":        contains,
+		"hasTag":          hasTag,
 		"env":             env,
 		"explode":         explode,
 		"in":              in,

--- a/template_functions.go
+++ b/template_functions.go
@@ -487,6 +487,22 @@ func hasTag(key string, services []*dep.CatalogService) []*dep.CatalogService {
 	return r
 }
 
+// groupByTag takes a list of services and a tag key
+// and returns a map of services, keyed on the tag value
+// services which do not have the specified tag are ignored
+func groupByTag(key string, services []*dep.CatalogService) map[string][]*dep.CatalogService {
+	m := map[string][]*dep.CatalogService{}
+
+	for _, s := range services {
+		tags := tagMap(s.Tags)
+		if v, exists := tags[key]; exists {
+			m[v] = append(m[v], s)
+		}
+	}
+
+	return m
+}
+
 // contains is a function that have reverse arguments of "in" and is designed to
 // be used as a pipe instead of a function:
 //

--- a/template_functions.go
+++ b/template_functions.go
@@ -472,6 +472,21 @@ func byDomainPath(services []*dep.CatalogService) map[string]map[string][]*dep.C
 	return m
 }
 
+// hasTag takes an list of services and a tag key
+// and returns services which have a tag with that key
+func hasTag(key string, services []*dep.CatalogService) []*dep.CatalogService {
+	r := []*dep.CatalogService{}
+
+	for _, s := range services {
+		tags := tagMap(s.Tags)
+		if _, exists := tags[key]; exists {
+			r = append(r, s)
+		}
+	}
+
+	return r
+}
+
 // contains is a function that have reverse arguments of "in" and is designed to
 // be used as a pipe instead of a function:
 //


### PR DESCRIPTION
For tcp streaming services, I'm feeling like I want to do something like:
{{range $port, $services := services | hasTag "tcp_stream" | groupByTag "tcp_port"}}

Don't actually strictly need hasTag, but I kinda wrote it whilst looking for the answer, and I think I prefer being specific about what kind of services these are. (Also, it feels like it would be generally useful).

groupByTag seems like a more generic way of doing byDomainPath:

{{range $domain, $srv := services | groupByTag "domain" }}
  {{range $location, $services := $srv | groupByTag "path" }}
  ...
  {{end}}
{{end}}
